### PR TITLE
Mastersyc double / half Bpm Fix. 

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -937,34 +937,19 @@ void BpmControl::notifySeek(double dNewPlaypos) {
 
 // called from an engine worker thread
 void BpmControl::trackLoaded(TrackPointer pNewTrack) {
-    if (kLogger.traceEnabled()) {
-        kLogger.trace() << getGroup() << "BpmControl::trackLoaded";
-    }
-    if (m_pTrack) {
-        disconnect(m_pTrack.get(), &Track::beatsUpdated,
-                   this, &BpmControl::slotUpdatedTrackBeats);
-    }
-
-    // reset for a new track
-    resetSyncAdjustment();
-
+    BeatsPointer pBeats;
     if (pNewTrack) {
-        m_pTrack = pNewTrack;
-        m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.get(), &Track::beatsUpdated,
-                this, &BpmControl::slotUpdatedTrackBeats);
-    } else {
-        m_pTrack.reset();
-        m_pBeats.clear();
+        pBeats = pNewTrack->getBeats();
     }
+    trackBeatsUpdated(pBeats);
 }
 
-void BpmControl::slotUpdatedTrackBeats() {
-    TrackPointer pTrack = m_pTrack;
-    if (pTrack) {
-        resetSyncAdjustment();
-        m_pBeats = pTrack->getBeats();
+void BpmControl::trackBeatsUpdated(BeatsPointer pBeats) {
+    if (kLogger.traceEnabled()) {
+        kLogger.trace() << getGroup() << "BpmControl::trackBeatsUpdated";
     }
+    resetSyncAdjustment();
+    m_pBeats = pBeats;
 }
 
 void BpmControl::slotBeatsTranslate(double v) {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -63,10 +63,6 @@ BpmControl::BpmControl(QString group,
     m_pLoopStartPosition = new ControlProxy(group, "loop_start_position", this);
     m_pLoopEndPosition = new ControlProxy(group, "loop_end_position", this);
 
-    m_pFileBpm = new ControlObject(ConfigKey(group, "file_bpm"));
-    connect(m_pFileBpm, &ControlObject::valueChanged,
-            this, &BpmControl::slotFileBpmChanged,
-            Qt::DirectConnection);
     m_pLocalBpm = new ControlObject(ConfigKey(group, "local_bpm"));
     m_pAdjustBeatsFaster = new ControlPushButton(ConfigKey(group, "beats_adjust_faster"), false);
     connect(m_pAdjustBeatsFaster, &ControlObject::valueChanged,
@@ -143,7 +139,6 @@ BpmControl::BpmControl(QString group,
 }
 
 BpmControl::~BpmControl() {
-    delete m_pFileBpm;
     delete m_pLocalBpm;
     delete m_pEngineBpm;
     delete m_pButtonTap;
@@ -160,29 +155,6 @@ BpmControl::~BpmControl() {
 
 double BpmControl::getBpm() const {
     return m_pEngineBpm->get();
-}
-
-void BpmControl::slotFileBpmChanged(double file_bpm) {
-    // Adjust the file-bpm with the current setting of the rate to get the
-    // engine BPM. We only do this for SYNC_NONE decks because EngineSync will
-    // set our BPM if the file BPM changes. See SyncControl::fileBpmChanged().
-    if (kLogger.traceEnabled()) {
-        kLogger.trace() << getGroup() << "BpmControl::slotFileBpmChanged" << file_bpm;
-    }
-    BeatsPointer pBeats = m_pBeats;
-    if (pBeats) {
-        const double beats_bpm =
-                pBeats->getBpmAroundPosition(
-                        getSampleOfTrack().current, kLocalBpmSpan);
-        if (beats_bpm != -1) {
-            m_pLocalBpm->set(beats_bpm);
-        } else {
-            m_pLocalBpm->set(file_bpm);
-        }
-    } else {
-        m_pLocalBpm->set(file_bpm);
-    }
-    resetSyncAdjustment();
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
@@ -946,10 +918,12 @@ void BpmControl::trackLoaded(TrackPointer pNewTrack) {
 
 void BpmControl::trackBeatsUpdated(BeatsPointer pBeats) {
     if (kLogger.traceEnabled()) {
-        kLogger.trace() << getGroup() << "BpmControl::trackBeatsUpdated";
+        kLogger.trace() << getGroup() << "BpmControl::trackBeatsUpdated"
+                        << (pBeats ? pBeats->getBpm() : 0.0);
     }
-    resetSyncAdjustment();
     m_pBeats = pBeats;
+    updateLocalBpm();
+    resetSyncAdjustment();
 }
 
 void BpmControl::slotBeatsTranslate(double v) {
@@ -985,10 +959,8 @@ double BpmControl::updateLocalBpm() {
         local_bpm = pBeats->getBpmAroundPosition(
                 getSampleOfTrack().current, kLocalBpmSpan);
         if (local_bpm == -1) {
-            local_bpm = m_pFileBpm->get();
+            local_bpm = pBeats->getBpm();
         }
-    } else {
-        local_bpm = m_pFileBpm->get();
     }
     if (local_bpm != prev_local_bpm) {
         if (kLogger.traceEnabled()) {

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -77,7 +77,6 @@ class BpmControl : public EngineControl {
     void trackBeatsUpdated(BeatsPointer pBeats) override;
 
   private slots:
-    void slotFileBpmChanged(double);
     void slotAdjustBeatsFaster(double);
     void slotAdjustBeatsSlower(double);
     void slotTranslateBeatsEarlier(double);
@@ -120,8 +119,6 @@ class BpmControl : public EngineControl {
     ControlProxy* m_pLoopStartPosition;
     ControlProxy* m_pLoopEndPosition;
 
-    // The current loaded file's detected BPM
-    ControlObject* m_pFileBpm;
     // The average bpm around the current playposition;
     ControlObject* m_pLocalBpm;
     ControlPushButton* m_pAdjustBeatsFaster;

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -74,6 +74,7 @@ class BpmControl : public EngineControl {
     double getRateRatio() const;
     void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
+    void trackBeatsUpdated(BeatsPointer pBeats) override;
 
   private slots:
     void slotFileBpmChanged(double);
@@ -88,7 +89,6 @@ class BpmControl : public EngineControl {
     void slotBpmTap(double);
     void slotUpdateRateSlider(double v = 0.0);
     void slotUpdateEngineBpm(double v = 0.0);
-    void slotUpdatedTrackBeats();
     void slotBeatsTranslate(double);
     void slotBeatsTranslateMatchAlignment(double);
 
@@ -159,8 +159,7 @@ class BpmControl : public EngineControl {
     double m_dLastSyncAdjustment;
     bool m_dUserTweakingSync;
 
-    // objects below are written from an engine worker thread
-    TrackPointer m_pTrack;
+    // m_pBeats is written from an engine worker thread
     BeatsPointer m_pBeats;
 
     FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -19,31 +19,17 @@ ClockControl::~ClockControl() {
 
 // called from an engine worker thread
 void ClockControl::trackLoaded(TrackPointer pNewTrack) {
-    // Clear on-beat control
-    m_pCOBeatActive->set(0.0);
-
-    // Disconnect any previously loaded track/beats
-    if (m_pTrack) {
-        disconnect(m_pTrack.get(), &Track::beatsUpdated,
-                   this, &ClockControl::slotBeatsUpdated);
-    }
+    BeatsPointer pBeats;
     if (pNewTrack) {
-        m_pTrack = pNewTrack;
-        m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.get(), &Track::beatsUpdated,
-                this, &ClockControl::slotBeatsUpdated);
-    } else {
-        m_pBeats.clear();
-        m_pTrack.reset();
+        pBeats = pNewTrack->getBeats();
     }
-
+    trackBeatsUpdated(pBeats);
 }
 
-void ClockControl::slotBeatsUpdated() {
-    TrackPointer pTrack = m_pTrack;
-    if(pTrack) {
-        m_pBeats = pTrack->getBeats();
-    }
+void ClockControl::trackBeatsUpdated(BeatsPointer pBeats) {
+    // Clear on-beat control
+    m_pCOBeatActive->set(0.0);
+    m_pBeats = pBeats;
 }
 
 void ClockControl::process(const double dRate,

--- a/src/engine/controls/clockcontrol.h
+++ b/src/engine/controls/clockcontrol.h
@@ -21,16 +21,14 @@ class ClockControl: public EngineControl {
     void process(const double dRate, const double currentSample,
             const int iBufferSize) override;
 
-  public slots:
     void trackLoaded(TrackPointer pNewTrack) override;
-    void slotBeatsUpdated();
+    void trackBeatsUpdated(BeatsPointer pBeats) override;
 
   private:
     ControlObject* m_pCOBeatActive;
     ControlProxy* m_pCOSampleRate;
 
-    // objects below are written from an engine worker thread
-    TrackPointer m_pTrack;
+    // m_pBeats is written from an engine worker thread
     BeatsPointer m_pBeats;
 };
 

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -369,10 +369,6 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
             this, &CueControl::trackCuesUpdated,
             Qt::DirectConnection);
 
-    connect(m_pLoadedTrack.get(), &Track::beatsUpdated,
-            this, &CueControl::trackBeatsUpdated,
-            Qt::DirectConnection);
-
     CuePointer pMainCue;
     for (const CuePointer& pCue : m_pLoadedTrack->getCuePoints()) {
         if (pCue->getType() == mixxx::CueType::MainCue) {
@@ -583,7 +579,8 @@ void CueControl::trackCuesUpdated() {
     loadCuesFromTrack();
 }
 
-void CueControl::trackBeatsUpdated() {
+void CueControl::trackBeatsUpdated(BeatsPointer pBeats) {
+    Q_UNUSED(pBeats);
     loadCuesFromTrack();
 }
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -132,6 +132,7 @@ class CueControl : public EngineControl {
     bool getPlayFlashingAtPause();
     SeekOnLoadMode getSeekOnLoadPreference();
     void trackLoaded(TrackPointer pNewTrack) override;
+    void trackBeatsUpdated(BeatsPointer pBeats) override;
 
   private slots:
     void quantizeChanged(double v);
@@ -139,7 +140,6 @@ class CueControl : public EngineControl {
     void cueUpdated();
     void trackAnalyzed();
     void trackCuesUpdated();
-    void trackBeatsUpdated();
     void hotcueSet(HotcueControl* pControl, double v);
     void hotcueGoto(HotcueControl* pControl, double v);
     void hotcueGotoAndPlay(HotcueControl* pControl, double v);

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -31,6 +31,10 @@ void EngineControl::trackLoaded(TrackPointer pNewTrack) {
     Q_UNUSED(pNewTrack);
 }
 
+void EngineControl::trackBeatsUpdated(BeatsPointer pBeats) {
+    Q_UNUSED(pBeats);
+}
+
 void EngineControl::hintReader(HintVector*) {
 }
 

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -67,6 +67,7 @@ class EngineControl : public QObject {
     // Called whenever a seek occurs to allow the EngineControl to respond.
     virtual void notifySeek(double dNewPlaypos);
     virtual void trackLoaded(TrackPointer pNewTrack);
+    virtual void trackBeatsUpdated(BeatsPointer pBeats);
 
   protected:
     struct SampleOfTrack {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -872,19 +872,18 @@ bool LoopingControl::isLoopingEnabled() {
 }
 
 void LoopingControl::trackLoaded(TrackPointer pNewTrack) {
-    if (m_pTrack) {
-        disconnect(m_pTrack.get(), &Track::beatsUpdated,
-                   this, &LoopingControl::slotUpdatedTrackBeats);
-    }
-
-    clearActiveBeatLoop();
-
+    m_pTrack = pNewTrack;
+    BeatsPointer pBeats;
     if (pNewTrack) {
-        m_pTrack = pNewTrack;
-        m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.get(), &Track::beatsUpdated,
-                this, &LoopingControl::slotUpdatedTrackBeats);
+        pBeats = pNewTrack->getBeats();
+    }
+    trackBeatsUpdated(pBeats);
+}
 
+void LoopingControl::trackBeatsUpdated(BeatsPointer pBeats) {
+    clearActiveBeatLoop();
+    m_pBeats = pBeats;
+    if (m_pBeats) {
         LoopSamples loopSamples = m_loopSamples.getValue();
         if (loopSamples.start != kNoTrigger && loopSamples.end != kNoTrigger) {
             double loaded_loop_size = findBeatloopSizeForLoop(
@@ -893,16 +892,6 @@ void LoopingControl::trackLoaded(TrackPointer pNewTrack) {
                 m_pCOBeatLoopSize->setAndConfirm(loaded_loop_size);
             }
         }
-    } else {
-        m_pTrack.reset();
-        m_pBeats.clear();
-    }
-}
-
-void LoopingControl::slotUpdatedTrackBeats() {
-    TrackPointer pTrack = m_pTrack;
-    if (pTrack) {
-        m_pBeats = pTrack->getBeats();
     }
 }
 

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -54,6 +54,9 @@ class LoopingControl : public EngineControl {
     void setRateControl(RateControl* rateControl);
     bool isLoopingEnabled();
 
+    void trackLoaded(TrackPointer pNewTrack) override;
+    void trackBeatsUpdated(BeatsPointer pBeats) override;
+
   public slots:
     void slotLoopIn(double pressed);
     void slotLoopInGoto(double);
@@ -64,8 +67,6 @@ class LoopingControl : public EngineControl {
     void slotReloopAndStop(double);
     void slotLoopStartPos(double);
     void slotLoopEndPos(double);
-    void trackLoaded(TrackPointer pNewTrack) override;
-    void slotUpdatedTrackBeats();
 
     // Generate a loop of 'beats' length. It can also do fractions for a
     // beatslicing effect.

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -33,22 +33,13 @@ QuantizeControl::~QuantizeControl() {
 }
 
 void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
-    if (m_pTrack) {
-        disconnect(m_pTrack.get(), &Track::beatsUpdated,
-                this, &QuantizeControl::slotBeatsUpdated);
-    }
-
     if (pNewTrack) {
-        m_pTrack = pNewTrack;
-        m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.get(), &Track::beatsUpdated,
-                this, &QuantizeControl::slotBeatsUpdated);
+        m_pBeats = pNewTrack->getBeats();
         // Initialize prev and next beat as if current position was zero.
         // If there is a cue point, the value will be updated.
         lookupBeatPositions(0.0);
         updateClosestBeat(0.0);
     } else {
-        m_pTrack.reset();
         m_pBeats.clear();
         m_pCOPrevBeat->set(-1);
         m_pCONextBeat->set(-1);
@@ -56,14 +47,11 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
     }
 }
 
-void QuantizeControl::slotBeatsUpdated() {
-    TrackPointer pTrack = m_pTrack;
-    if (pTrack) {
-        m_pBeats = pTrack->getBeats();
-        double current = getSampleOfTrack().current;
-        lookupBeatPositions(current);
-        updateClosestBeat(current);
-    }
+void QuantizeControl::trackBeatsUpdated(BeatsPointer pBeats) {
+    m_pBeats = pBeats;
+    double current = getSampleOfTrack().current;
+    lookupBeatPositions(current);
+    updateClosestBeat(current);
 }
 
 void QuantizeControl::setCurrentSample(const double dCurrentSample,

--- a/src/engine/controls/quantizecontrol.h
+++ b/src/engine/controls/quantizecontrol.h
@@ -22,9 +22,7 @@ class QuantizeControl : public EngineControl {
             const double dTotalSamples, const double dTrackSampleRate) override;
     void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
-
-  private slots:
-    void slotBeatsUpdated();
+    void trackBeatsUpdated(BeatsPointer pBeats) override;
 
   private:
     // Update positions of previous and next beats from beatgrid.
@@ -39,8 +37,7 @@ class QuantizeControl : public EngineControl {
     ControlObject* m_pCOPrevBeat;
     ControlObject* m_pCOClosestBeat;
 
-    // objects below are written from an engine worker thread
-    TrackPointer m_pTrack;
+    // m_pBeats is written from an engine worker thread
     BeatsPointer m_pBeats;
 };
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -195,7 +195,6 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pEngineSync = pMixingEngine->getEngineSync();
 
     m_pSyncControl = new SyncControl(group, pConfig, pChannel, m_pEngineSync);
-    addControl(m_pSyncControl);
 
 #ifdef __VINYLCONTROL__
     m_pVinylControlControl = new VinylControlControl(group, pConfig);
@@ -217,6 +216,7 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pRateControl->setBpmControl(m_pBpmControl);
     m_pSyncControl->setEngineControls(m_pRateControl, m_pBpmControl);
     pMixingEngine->getEngineSync()->addSyncableDeck(m_pSyncControl);
+    addControl(m_pSyncControl);
 
     m_fwdButton = ControlObject::getControl(ConfigKey(group, "fwd"));
     m_backButton = ControlObject::getControl(ConfigKey(group, "back"));
@@ -499,8 +499,6 @@ void EngineBuffer::loadFakeTrack(TrackPointer pTrack, bool bPlay) {
     }
     slotTrackLoaded(pTrack, pTrack->getSampleRate(),
                     pTrack->getSampleRate() * pTrack->getDurationInt());
-    m_pSyncControl->setLocalBpm(pTrack->getBpm());
-    m_pSyncControl->trackLoaded(pTrack);
 }
 
 // WARNING: Always called from the EngineWorker thread pool

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -208,6 +208,7 @@ class EngineBuffer : public EngineObject {
                              QString reason);
     // Fired when passthrough mode is enabled or disabled.
     void slotPassthroughChanged(double v);
+    void slotUpdatedTrackBeats();
 
   private:
     // Add an engine control to the EngineBuffer

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -107,19 +107,6 @@ void BaseSyncableListener::setMasterInstantaneousBpm(Syncable* pSource, double b
     }
 }
 
-void BaseSyncableListener::setMasterBaseBpm(Syncable* pSource, double bpm) {
-    if (pSource != m_pInternalClock) {
-        m_pInternalClock->setMasterBaseBpm(bpm);
-    }
-    foreach (Syncable* pSyncable, m_syncables) {
-        if (pSyncable == pSource ||
-                !pSyncable->isSynchronized()) {
-            continue;
-        }
-        pSyncable->setMasterBaseBpm(bpm);
-    }
-}
-
 void BaseSyncableListener::setMasterBeatDistance(Syncable* pSource, double beat_distance) {
     if (pSource != m_pInternalClock) {
         m_pInternalClock->setMasterBeatDistance(beat_distance);

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -51,24 +51,12 @@ Syncable* BaseSyncableListener::getSyncableForGroup(const QString& group) {
 }
 
 bool BaseSyncableListener::syncDeckExists() const {
-    foreach (const Syncable* pSyncable, m_syncables) {
+    for (auto& pSyncable : qAsConst(m_syncables)) {
         if (pSyncable->isSynchronized() && pSyncable->getBaseBpm() > 0) {
             return true;
         }
     }
     return false;
-}
-
-int BaseSyncableListener::playingSyncDeckCount() const {
-    int playing_sync_decks = 0;
-
-    foreach (const Syncable* pSyncable, m_syncables) {
-        if (pSyncable->isSynchronized() && pSyncable->isPlaying()) {
-            ++playing_sync_decks;
-        }
-    }
-
-    return playing_sync_decks;
 }
 
 double BaseSyncableListener::masterBpm() const {

--- a/src/engine/sync/basesyncablelistener.h
+++ b/src/engine/sync/basesyncablelistener.h
@@ -46,10 +46,6 @@ class BaseSyncableListener : public SyncableListener {
     // pSource.
     void setMasterInstantaneousBpm(Syncable* pSource, double bpm);
 
-    // Set the master base bpm, which is what the bpm would be if the syncable
-    // were playing at 1.0x speed
-    void setMasterBaseBpm(Syncable* pSource, double bpm);
-
     // Set the master beat distance on every sync-enabled Syncable except
     // pSource.
     void setMasterBeatDistance(Syncable* pSource, double beat_distance);

--- a/src/engine/sync/basesyncablelistener.h
+++ b/src/engine/sync/basesyncablelistener.h
@@ -19,9 +19,9 @@ class BaseSyncableListener : public SyncableListener {
 
     // Only for testing. Do not use.
     Syncable* getSyncableForGroup(const QString& group);
-    Syncable* getMasterSyncable() {
+    Syncable* getMasterSyncable() override {
         return m_pMasterSyncable;
-    }
+    };
 
   protected:
     // This utility method returns true if it finds a deck not in SYNC_NONE mode.

--- a/src/engine/sync/basesyncablelistener.h
+++ b/src/engine/sync/basesyncablelistener.h
@@ -24,15 +24,8 @@ class BaseSyncableListener : public SyncableListener {
     }
 
   protected:
-    // Choices about master selection can hinge on if any decks have sync
-    // mode enabled.  This utility method returns true if it finds a deck
-    // not in SYNC_NONE mode.
+    // This utility method returns true if it finds a deck not in SYNC_NONE mode.
     bool syncDeckExists() const;
-
-    // Choices about master selection can hinge on how many decks are playing
-    // back. This utility method counts the number of decks not in SYNC_NONE
-    // mode that are playing.
-    int playingSyncDeckCount() const;
 
     // Return the current BPM of the master Syncable. If no master syncable is
     // set then returns the BPM of the internal clock.

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -231,7 +231,6 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
         }
     } else if (newMaster) {
         // This happens if this Deck has no valid BPM
-        DEBUG_ASSERT(pSyncable->getBaseBpm() <= 0);
         // avoid that other decks are adjusted
         targetSyncable = newMaster;
     } else {
@@ -362,9 +361,8 @@ void EngineSync::activateMaster(Syncable* pSyncable, bool explicitMaster) {
                         << explicitMaster;
     }
 
-    // Already master, no need to do anything.
     if (m_pMasterSyncable == pSyncable) {
-        // Update the explicit State.
+        // Already master, update the explicit State.
         if (explicitMaster) {
             if (m_pMasterSyncable->getSyncMode() != SYNC_MASTER_EXPLICIT) {
                 m_pMasterSyncable->setSyncMode(SYNC_MASTER_EXPLICIT);
@@ -383,7 +381,7 @@ void EngineSync::activateMaster(Syncable* pSyncable, bool explicitMaster) {
 
     m_pMasterSyncable = nullptr;
     if (pOldChannelMaster) {
-        activateFollower(pOldChannelMaster);
+        pOldChannelMaster->setSyncMode(SYNC_FOLLOWER);
     }
 
     //qDebug() << "Setting up master " << pSyncable->getGroup();
@@ -393,6 +391,9 @@ void EngineSync::activateMaster(Syncable* pSyncable, bool explicitMaster) {
     } else {
         pSyncable->setSyncMode(SYNC_MASTER_SOFT);
     }
+    pSyncable->setMasterParams(masterBeatDistance(), masterBaseBpm(), masterBpm());
+    pSyncable->setInstantaneousBpm(masterBpm());
+
     if (m_pMasterSyncable != m_pInternalClock) {
         activateFollower(m_pInternalClock);
     }
@@ -422,7 +423,6 @@ void EngineSync::deactivateSync(Syncable* pSyncable) {
     }
 
     Syncable* newMaster = pickMaster(nullptr);
-
     if (newMaster != nullptr && m_pMasterSyncable != newMaster) {
         activateMaster(newMaster, false);
     }

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -300,19 +300,19 @@ void EngineSync::requestBpmUpdate(Syncable* pSyncable, double bpm) {
 
     double mbaseBpm = 0.0;
     double mbpm = 0.0;
+    double beatDistance = 0.0;
     if (m_pMasterSyncable) {
         mbaseBpm = m_pMasterSyncable->getBaseBpm();
         mbpm = m_pMasterSyncable->getBpm();
+        beatDistance = m_pMasterSyncable->getBeatDistance();
     }
 
     if (mbaseBpm != 0.0 && mbpm != 0.0) {
         // resync to current master
-        pSyncable->setMasterBaseBpm(mbaseBpm);
-        pSyncable->setMasterBpm(mbpm);
+        pSyncable->setMasterParams(beatDistance, mbaseBpm, mbpm);
     } else {
         // There is no other master, adopt this bpm as master
-        pSyncable->setMasterBaseBpm(pSyncable->getBaseBpm());
-        pSyncable->setMasterBpm(bpm);
+        pSyncable->setMasterParams(0.0, 0.0, bpm);
     }
 }
 

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -49,32 +49,18 @@ Syncable* EngineSync::pickMaster(Syncable* enabling_syncable) {
     int stopped_deck_count = 0;
     int playing_deck_count = 0;
 
-    if (enabling_syncable != nullptr && enabling_syncable->getBaseBpm() != 0.0) {
-        if (enabling_syncable->isPlaying()) {
-            if (playing_deck_count == 0) {
-                first_playing_deck = enabling_syncable;
-            }
-            playing_deck_count++;
-        } else {
-            if (stopped_deck_count == 0) {
-                first_stopped_deck = enabling_syncable;
-            }
-            stopped_deck_count++;
-        }
-    }
-
     for (const auto& pSyncable : m_syncables) {
-        if (pSyncable == enabling_syncable) {
+        if (pSyncable->getBaseBpm() <= 0.0) {
             continue;
         }
-        if (!pSyncable->getChannel()->isPrimaryDeck()) {
-            continue;
-        }
-        if (!pSyncable->isSynchronized()) {
-            continue;
-        }
-        if (pSyncable->getBaseBpm() == 0.0) {
-            continue;
+
+        if (pSyncable != enabling_syncable) {
+            if (!pSyncable->getChannel()->isPrimaryDeck()) {
+                continue;
+            }
+            if (!pSyncable->isSynchronized()) {
+                continue;
+            }
         }
 
         if (pSyncable->isPlaying()) {

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -46,7 +46,6 @@ class EngineSync : public BaseSyncableListener {
     void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance) override;
     void notifyPlaying(Syncable* pSyncable, bool playing) override;
     void notifyScratching(Syncable* pSyncable, bool scratching) override;
-    void notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm) override;
 
     // Used to pick a sync target for non-master-sync mode.
     EngineChannel* pickNonSyncSyncTarget(EngineChannel* pDontPick) const;

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -14,7 +14,7 @@ InternalClock::InternalClock(const char* pGroup, SyncableListener* pEngineSync)
           m_mode(SYNC_NONE),
           m_iOldSampleRate(44100),
           m_dOldBpm(124.0),
-          m_baseBpm(124.0),
+          m_dbaseBpm(124.0),
           m_bClockUpdated(false),
           m_dBeatLength(m_iOldSampleRate * 60.0 / m_dOldBpm),
           m_dClockPosition(0) {
@@ -103,8 +103,7 @@ void InternalClock::setMasterBeatDistance(double beatDistance) {
 }
 
 double InternalClock::getBaseBpm() const {
-    qDebug() << "InternalClock::getBaseBpm()" << m_baseBpm;
-    return m_baseBpm;
+    return m_dbaseBpm;
 }
 
 double InternalClock::getBpm() const {
@@ -131,13 +130,13 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
     if (bpm == 0) {
         return;
     }
-    m_baseBpm = baseBpm;
+    m_dbaseBpm = baseBpm;
     setMasterBpm(bpm);
     setMasterBeatDistance(beatDistance);
 }
 
 void InternalClock::slotBpmChanged(double bpm) {
-    m_baseBpm = bpm;
+    m_dbaseBpm = bpm;
     updateBeatLength(m_iOldSampleRate, bpm);
     if (!isSynchronized()) {
         return;

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -14,7 +14,7 @@ InternalClock::InternalClock(const char* pGroup, SyncableListener* pEngineSync)
           m_mode(SYNC_NONE),
           m_iOldSampleRate(44100),
           m_dOldBpm(124.0),
-          m_dbaseBpm(124.0),
+          m_dBaseBpm(124.0),
           m_bClockUpdated(false),
           m_dBeatLength(m_iOldSampleRate * 60.0 / m_dOldBpm),
           m_dClockPosition(0) {
@@ -103,7 +103,7 @@ void InternalClock::setMasterBeatDistance(double beatDistance) {
 }
 
 double InternalClock::getBaseBpm() const {
-    return m_dbaseBpm;
+    return m_dBaseBpm;
 }
 
 double InternalClock::getBpm() const {
@@ -130,13 +130,13 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
     if (bpm == 0) {
         return;
     }
-    m_dbaseBpm = baseBpm;
+    m_dBaseBpm = baseBpm;
     setMasterBpm(bpm);
     setMasterBeatDistance(beatDistance);
 }
 
 void InternalClock::slotBpmChanged(double bpm) {
-    m_dbaseBpm = bpm;
+    m_dBaseBpm = bpm;
     updateBeatLength(m_iOldSampleRate, bpm);
     if (!isSynchronized()) {
         return;

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -61,20 +61,22 @@ void InternalClock::requestSync() {
 }
 
 void InternalClock::slotSyncMasterEnabledChangeRequest(double state) {
-    bool currentlyMaster = isMaster(getSyncMode());
-
+    SyncMode mode = m_mode;
+    //Note: internal clock is always sync enabled
     if (state > 0.0) {
-        if (currentlyMaster) {
+        if (mode == SYNC_MASTER_EXPLICIT) {
             // Already master.
             return;
         }
-        // Internal clock can never be explicit master.  If we ever have something like a
-        // midi clock, *that* can be explicit master, but the internal clock is just around
-        // to hand off and coordinate other decks.
-        m_pEngineSync->requestSyncMode(this, SYNC_MASTER_SOFT);
+        if (mode == SYNC_MASTER_SOFT) {
+            // user request: make master explicite
+            m_mode = SYNC_MASTER_EXPLICIT;
+            return;
+        }
+        m_pEngineSync->requestSyncMode(this, SYNC_MASTER_EXPLICIT);
     } else {
         // Turning off master goes back to follower mode.
-        if (!currentlyMaster) {
+        if (mode == SYNC_FOLLOWER) {
             // Already not master.
             return;
         }

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -14,6 +14,7 @@ InternalClock::InternalClock(const char* pGroup, SyncableListener* pEngineSync)
           m_mode(SYNC_NONE),
           m_iOldSampleRate(44100),
           m_dOldBpm(124.0),
+          m_baseBpm(124.0),
           m_bClockUpdated(false),
           m_dBeatLength(m_iOldSampleRate * 60.0 / m_dOldBpm),
           m_dClockPosition(0) {
@@ -102,7 +103,8 @@ void InternalClock::setMasterBeatDistance(double beatDistance) {
 }
 
 double InternalClock::getBaseBpm() const {
-    return m_dOldBpm;
+    qDebug() << "InternalClock::getBaseBpm()" << m_baseBpm;
+    return m_baseBpm;
 }
 
 double InternalClock::getBpm() const {
@@ -110,7 +112,7 @@ double InternalClock::getBpm() const {
 }
 
 void InternalClock::setMasterBpm(double bpm) {
-    //qDebug() << "InternalClock::setBpm" << bpm;
+    qDebug() << "InternalClock::setBpm" << bpm;
     if (bpm == 0) {
         return;
     }
@@ -125,16 +127,17 @@ void InternalClock::setInstantaneousBpm(double bpm) {
 }
 
 void InternalClock::setMasterParams(double beatDistance, double baseBpm, double bpm) {
-    Q_UNUSED(baseBpm)
     //qDebug() << "InternalClock::setMasterParams" << beatDistance << baseBpm << bpm;
     if (bpm == 0) {
         return;
     }
+    m_baseBpm = baseBpm;
     setMasterBpm(bpm);
     setMasterBeatDistance(beatDistance);
 }
 
 void InternalClock::slotBpmChanged(double bpm) {
+    m_baseBpm = bpm;
     updateBeatLength(m_iOldSampleRate, bpm);
     if (!isSynchronized()) {
         return;

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -105,10 +105,6 @@ double InternalClock::getBaseBpm() const {
     return m_dOldBpm;
 }
 
-void InternalClock::setMasterBaseBpm(double bpm) {
-    Q_UNUSED(bpm)
-}
-
 double InternalClock::getBpm() const {
     return m_pClockBpm->get();
 }

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -44,7 +44,6 @@ class InternalClock : public QObject, public Clock, public Syncable {
     void setMasterBeatDistance(double beatDistance);
 
     double getBaseBpm() const;
-    void setMasterBaseBpm(double);
     void setMasterBpm(double bpm);
     double getBpm() const;
     void setInstantaneousBpm(double bpm);

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -69,7 +69,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
 
     int m_iOldSampleRate;
     double m_dOldBpm;
-    double m_baseBpm;
+    double m_dbaseBpm;
     QAtomicInteger<bool> m_bClockUpdated;
 
     // The internal clock rate is stored in terms of samples per beat.

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -69,6 +69,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
 
     int m_iOldSampleRate;
     double m_dOldBpm;
+    double m_baseBpm;
     QAtomicInteger<bool> m_bClockUpdated;
 
     // The internal clock rate is stored in terms of samples per beat.

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -69,7 +69,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
 
     int m_iOldSampleRate;
     double m_dOldBpm;
-    double m_dbaseBpm;
+    double m_dBaseBpm;
     QAtomicInteger<bool> m_bClockUpdated;
 
     // The internal clock rate is stored in terms of samples per beat.

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -76,11 +76,7 @@ class Syncable {
     // Must never result in a call to
     // SyncableListener::notifyBeatDistanceChanged or signal loops could occur.
     virtual void setMasterBeatDistance(double beatDistance) = 0;
-    // Reports what the bpm of the master would be if it were playing back at
-    // a rate of 1.0x.  This is used by syncables to decide if they should
-    // match rates at x2 or /2 speed.  If we were to use the regular BPM, the
-    // change of a rate slider might suddenly change the sync multiplier.
-    virtual void setMasterBaseBpm(double) = 0;
+
     // Must never result in a call to SyncableListener::notifyBpmChanged or
     // signal loops could occur.
     virtual void setMasterBpm(double bpm) = 0;

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -128,11 +128,8 @@ class SyncableListener {
             Syncable* pSyncable, double beatDistance) = 0;
 
     virtual void notifyPlaying(Syncable* pSyncable, bool playing) = 0;
-    // A syncable can notify that a track has been loaded, and passes in the bpm
-    // that it would be set at if the rate slider were left alone.  This allows
-    // the master sync engine to either use that rate, if it pleases, or sets
-    // the syncable to the existing master bpm.
-    virtual void notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm) = 0;
+
+    virtual Syncable* getMasterSyncable() = 0;
 };
 
 #endif /* SYNCABLE_H */

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -222,18 +222,6 @@ void SyncControl::setMasterBeatDistance(double beatDistance) {
     updateTargetBeatDistance();
 }
 
-void SyncControl::setMasterBaseBpm(double bpm) {
-    m_masterBpmAdjustFactor = determineBpmMultiplier(fileBpm(), bpm);
-    qDebug() << getGroup() << "setMasterBaseBpm <-" << fileBpm() << bpm << "*"
-             << m_masterBpmAdjustFactor;
-    if (kLogger.traceEnabled()) {
-        kLogger.trace() << "SyncControl::setMasterBaseBpm" << getGroup() << bpm
-                        << m_masterBpmAdjustFactor;
-    }
-    // Update the target beat distance in case the multiplier changed.
-    updateTargetBeatDistance();
-}
-
 void SyncControl::setMasterBpm(double bpm) {
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "SyncControl::setMasterBpm" << bpm;
@@ -266,7 +254,7 @@ void SyncControl::setMasterParams(
 
 double SyncControl::determineBpmMultiplier(double myBpm, double targetBpm) const {
     double multiplier = kBpmUnity;
-    if (myBpm == 0.0) {
+    if (myBpm == 0.0 || targetBpm == 0.0) {
         return multiplier;
     }
     double best_margin = fabs((targetBpm / myBpm) - 1.0);

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -399,11 +399,15 @@ void SyncControl::slotSyncModeChangeRequest(double state) {
 }
 
 void SyncControl::slotSyncMasterEnabledChangeRequest(double state) {
-    bool currentlyMaster = isMaster(getSyncMode());
-
+    SyncMode mode = getSyncMode();
     if (state > 0.0) {
-        if (currentlyMaster) {
+        if (mode == SYNC_MASTER_EXPLICIT) {
             // Already master.
+            return;
+        }
+        if (mode == SYNC_MASTER_SOFT) {
+            // user request: make master explicite
+            m_pSyncMode->setAndConfirm(SYNC_MASTER_EXPLICIT);
             return;
         }
         if (m_pPassthroughEnabled->get()) {
@@ -413,7 +417,7 @@ void SyncControl::slotSyncMasterEnabledChangeRequest(double state) {
         m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_MASTER_EXPLICIT);
     } else {
         // Turning off master goes back to follower mode.
-        if (!currentlyMaster) {
+        if (mode == SYNC_FOLLOWER) {
             // Already not master.
             return;
         }

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -60,6 +60,7 @@ class SyncControl : public EngineControl, public Syncable {
     void reportPlayerSpeed(double speed, bool scratching);
     void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
+    void trackBeatsUpdated(BeatsPointer pBeats) override;
 
   private slots:
     // Fired by changes in play.

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -43,7 +43,7 @@ class SyncControl : public EngineControl, public Syncable {
     // Must never result in a call to
     // SyncableListener::notifyBeatDistanceChanged or signal loops could occur.
     void setMasterBeatDistance(double beatDistance) override;
-    void setMasterBaseBpm(double) override;
+
     // Must never result in a call to
     // SyncableListener::notifyBpmChanged or signal loops could occur.
     void setMasterBpm(double bpm) override;

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -78,9 +78,6 @@ class SyncControl : public EngineControl, public Syncable {
     // Fired by changes in rate, rate_dir, rateRange.
     void slotRateChanged();
 
-    // Fired by changes in file_bpm.
-    void slotFileBpmChanged();
-
     // Change request handlers for sync properties.
     void slotSyncModeChangeRequest(double state);
     void slotSyncEnabledChangeRequest(double enabled);
@@ -93,6 +90,7 @@ class SyncControl : public EngineControl, public Syncable {
     // best factor for multiplying the master bpm to get a bpm this syncable
     // should match against.
     double determineBpmMultiplier(double myBpm, double targetBpm) const;
+    double fileBpm() const;
 
     QString m_sGroup;
     // The only reason we have this pointer is an optimzation so that the
@@ -126,13 +124,15 @@ class SyncControl : public EngineControl, public Syncable {
     ControlProxy* m_pPlayButton;
     ControlProxy* m_pBpm;
     ControlProxy* m_pLocalBpm;
-    ControlProxy* m_pFileBpm;
     ControlProxy* m_pRateRatio;
     ControlProxy* m_pVCEnabled;
     ControlProxy* m_pPassthroughEnabled;
     ControlProxy* m_pEjectButton;
     ControlProxy* m_pSyncPhaseButton;
     ControlProxy* m_pQuantize;
+
+    // m_pBeats is written from an engine worker thread
+    BeatsPointer m_pBeats;
 };
 
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -1,26 +1,27 @@
-#include <QMessageBox>
-
 #include "mixer/basetrackplayer.h"
-#include "mixer/playerinfo.h"
-#include "mixer/playermanager.h"
+
+#include <QMessageBox>
 
 #include "control/controlobject.h"
 #include "control/controlpotmeter.h"
-#include "track/track.h"
-#include "sources/soundsourceproxy.h"
-#include "engine/enginebuffer.h"
-#include "engine/controls/enginecontrol.h"
+#include "effects/effectsmanager.h"
 #include "engine/channels/enginedeck.h"
+#include "engine/controls/enginecontrol.h"
 #include "engine/engine.h"
+#include "engine/enginebuffer.h"
 #include "engine/enginemaster.h"
+#include "engine/sync/enginesync.h"
+#include "mixer/playerinfo.h"
+#include "mixer/playermanager.h"
+#include "sources/soundsourceproxy.h"
 #include "track/beatgrid.h"
-#include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/visualsmanager.h"
+#include "track/track.h"
+#include "util/compatibility.h"
 #include "util/platform.h"
 #include "util/sandbox.h"
-#include "effects/effectsmanager.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
-#include "engine/sync/enginesync.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/visualsmanager.h"
 
 namespace {
 
@@ -134,7 +135,8 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
 
     m_pPreGain = std::make_unique<ControlProxy>(group, "pregain", this);
     // BPM of the current song
-    m_pFileBPM = std::make_unique<ControlProxy>(group, "file_bpm", this);
+
+    m_pFileBPM = std::make_unique<ControlObject>(ConfigKey(group, "file_bpm"));
     m_pKey = std::make_unique<ControlProxy>(group, "file_key", this);
 
     m_pReplayGain = std::make_unique<ControlProxy>(group, "replaygain", this);
@@ -166,7 +168,7 @@ TrackPointer BaseTrackPlayerImpl::loadFakeTrack(bool bPlay, double filebpm) {
         connect(m_pLoadedTrack.get(),
                 &Track::bpmUpdated,
                 m_pFileBPM.get(),
-                &ControlProxy::set);
+                QOverload<double>::of(&ControlObject::set));
 
         connect(m_pLoadedTrack.get(),
                 &Track::keyUpdated,
@@ -284,7 +286,7 @@ void BaseTrackPlayerImpl::connectLoadedTrack() {
     connect(m_pLoadedTrack.get(),
             &Track::bpmUpdated,
             m_pFileBPM.get(),
-            &ControlProxy::set);
+            QOverload<double>::of(&ControlObject::set));
     connect(m_pLoadedTrack.get(),
             &Track::keyUpdated,
             m_pKey.get(),

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -129,7 +129,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
     // TODO() these COs are reconnected during runtime
     // This may lock the engine
-    std::unique_ptr<ControlProxy> m_pFileBPM;
+    std::unique_ptr<ControlObject> m_pFileBPM;
     std::unique_ptr<ControlProxy> m_pKey;
 
     std::unique_ptr<ControlProxy> m_pReplayGain;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -645,13 +645,8 @@ TEST_F(EngineSyncTest, MasterStopSliderCheck) {
 TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     // If Internal is master, and we turn sync on a playing deck, the playing deck sets the
     // internal master and the beat distances are now aligned.
-
-    auto pButtonMasterSyncInternal = std::make_unique<ControlProxy>(m_sInternalClockGroup, "sync_master");
-
-    // Set internal to master and give it a beat distance.
     ControlObject::set(ConfigKey(m_sInternalClockGroup, "bpm"), 124.0);
     ControlObject::set(ConfigKey(m_sInternalClockGroup, "beat_distance"), 0.5);
-    pButtonMasterSyncInternal->set(SYNC_MASTER_SOFT);
     ProcessBuffer();
 
     // Set up the deck to play.
@@ -1059,12 +1054,9 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
 }
 
 TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
-    auto pButtonMasterSyncInternal = std::make_unique<ControlProxy>(m_sInternalClockGroup, "sync_master");
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
-
-    pButtonMasterSyncInternal->set(1.0);
 
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
     m_pTrack1->setBeats(pBeats1);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1292,7 +1292,10 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
 
-    EXPECT_FLOAT_EQ(175.0,
+    // We Expect that m_sGroup1 has adjusted its own bpm to the second deck and becomes a single master.
+    // When the second deck is synced the master bpm is adopted by the interna clock, which becomes now
+    // the master
+    EXPECT_FLOAT_EQ(87.5,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
     EXPECT_FLOAT_EQ(87.5,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
@@ -1376,8 +1379,8 @@ TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
 
-    EXPECT_FLOAT_EQ(140.0,
-                ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
+    EXPECT_FLOAT_EQ(70.0,
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
     EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
                     ControlObject::getControl(
                             ConfigKey(m_sGroup1, "rate"))->get());

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -733,6 +733,8 @@ TEST_F(EngineSyncTest, LoadTrackInitializesMaster) {
 
     // No master because this deck has no track.
     EXPECT_EQ(NULL, m_pEngineSync->getMaster());
+    EXPECT_FLOAT_EQ(0.0,
+            ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // The track load doesn't trigger a master change, so still no master.
     m_pMixerDeck1->loadFakeTrack(false, 140.0);
@@ -1067,8 +1069,9 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     EXPECT_FLOAT_EQ(0.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
-    // Group1 is still master because there are no other sync decks.
-    assertIsSoftMaster(m_sGroup1);
+    assertIsSoftMaster(m_sInternalClockGroup);
+    assertIsFollower(m_sGroup1);
+    assertSyncOff(m_sGroup2);
 
     m_pMixerDeck1->loadFakeTrack(false, 128.0);
     EXPECT_FLOAT_EQ(128.0,
@@ -1086,9 +1089,9 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     m_pTrack1->setBeats(BeatsPointer());
     ProcessBuffer();
 
-    assertIsSoftMaster(m_sInternalClockGroup);
+    assertIsFollower(m_sInternalClockGroup);
     assertIsFollower(m_sGroup1);
-    assertIsFollower(m_sGroup2);
+    assertIsSoftMaster(m_sGroup2);
 }
 
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -143,10 +143,10 @@ TEST_F(EngineSyncTest, SetMasterSuccess) {
 TEST_F(EngineSyncTest, ExplicitMasterPersists) {
     // If we set an explicit master, enabling sync or pressing play on other decks
     // doesn't cause the master to move around.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm1->set(120.0);
-    pFileBpm2->set(124.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    m_pTrack1->setBeats(pBeats1);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
+    m_pTrack2->setBeats(pBeats2);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -173,14 +173,12 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
 
 TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
     // Make sure we don't get two master lights if we change masters while playing.
-
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    auto pFileBpm3 = std::make_unique<ControlProxy>(m_sGroup3, "file_bpm");
-
-    pFileBpm1->set(120.0);
-    pFileBpm2->set(124.0);
-    pFileBpm3->set(128.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    m_pTrack1->setBeats(pBeats1);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
+    m_pTrack2->setBeats(pBeats2);
+    BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 128, 0.0);
+    m_pTrack3->setBeats(pBeats3);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->set(SYNC_MASTER_EXPLICIT);
@@ -227,11 +225,11 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
     assertIsExplicitMaster(m_sInternalClockGroup);
 
     // Make sure both decks are playing.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(80.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(80.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 80, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
 
@@ -246,13 +244,13 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 
 TEST_F(EngineSyncTest, DisableSyncOnMaster) {
     // Channel 1 follower, channel 2 master.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncMode1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->slotSet(SYNC_FOLLOWER);
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(130.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncMaster2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
     pButtonSyncMaster2->slotSet(1.0);
 
@@ -276,8 +274,8 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
     pMasterSyncSlider->set(100.0);
 
     // Set the file bpm of channel 1 to 160bpm.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(80.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    m_pTrack1->setBeats(pBeats1);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_FOLLOWER);
@@ -292,8 +290,8 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // If there exists a sync deck, even if it's not playing, don't change the
     // master BPM if a new deck enables sync.
 
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(80.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
 
@@ -301,8 +299,8 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     EXPECT_FLOAT_EQ(80.0,
                     ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(100.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
 
@@ -319,12 +317,12 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(100.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(130.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
     ProcessBuffer();
@@ -425,8 +423,8 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(160.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
     ProcessBuffer();
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -441,8 +439,8 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     EXPECT_FLOAT_EQ(192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     EXPECT_FLOAT_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
     // rate slider for channel 2 should now be 1.6 = 160 * 1.2 / 120.
@@ -460,13 +458,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(160.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
@@ -482,13 +480,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(160.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     EXPECT_FLOAT_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
     // Turn on Master and Follower.
@@ -519,12 +517,12 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(160.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
@@ -562,13 +560,13 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     assertIsFollower(m_sGroup2);
 
     // Set the file bpm of channel 1 to 160bpm.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(160.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     EXPECT_FLOAT_EQ(120.0, ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
 
     // Set the internal rate to 150.
@@ -606,10 +604,10 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
 TEST_F(EngineSyncTest, MasterStopSliderCheck) {
     // If the master is playing, and stop is pushed, the sliders should stay the same.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(120.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(128.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    m_pTrack1->setBeats(pBeats1);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
+    m_pTrack2->setBeats(pBeats2);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
@@ -645,7 +643,6 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     // internal master and the beat distances are now aligned.
 
     auto pButtonMasterSyncInternal = std::make_unique<ControlProxy>(m_sInternalClockGroup, "sync_master");
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
 
     // Set internal to master and give it a beat distance.
     ControlObject::set(ConfigKey(m_sInternalClockGroup, "bpm"), 124.0);
@@ -654,7 +651,8 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     ProcessBuffer();
 
     // Set up the deck to play.
-    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -677,8 +675,8 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
                                                         "beat_distance")));
 
     // Enable second deck, bpm and beat distance should still match original setting.
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(140.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->set(0.2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -700,10 +698,9 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
 TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     // Enabling sync on a deck causes it to be master, and sets bpm and clock.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-
     // Set the deck to play.
-    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -884,8 +881,8 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
     // If we enable a deck to be master, the internal slider should immediately update.
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
 
     // Set the deck to sync enabled.
@@ -907,12 +904,12 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(100.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -983,12 +980,12 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(100.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(130.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
     ProcessBuffer();
@@ -1058,23 +1055,26 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 
     pButtonMasterSyncInternal->set(1.0);
 
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(120.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
 
     ProcessBuffer();
     pButtonEject1->set(1.0);
     // When an eject happens, the bpm gets set to zero.
-    pFileBpm1->set(0.0);
     ProcessBuffer();
+
+    EXPECT_FLOAT_EQ(0.0,
+            ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // Group1 is still master because there are no other sync decks.
     assertIsSoftMaster(m_sGroup1);
 
-    // Try again with multiple sync decks
-    pFileBpm1->set(128.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(135.0);
+    m_pMixerDeck1->loadFakeTrack(false, 128.0);
+    EXPECT_FLOAT_EQ(128.0,
+            ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 135, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
@@ -1083,7 +1083,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     assertIsFollower(m_sGroup2);
 
     pButtonEject1->set(1.0);
-    pFileBpm1->set(0.0);
+    m_pTrack1->setBeats(BeatsPointer());
     ProcessBuffer();
 
     assertIsSoftMaster(m_sInternalClockGroup);
@@ -1093,19 +1093,20 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     // If filebpm changes, don't treat it like a rate change.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(100.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
-    pFileBpm1->set(160.0);
+    pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(100.0,
                     ControlObject::get(ConfigKey(m_sInternalClockGroup,
                                                         "bpm")));
@@ -1115,9 +1116,9 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
     // Regression test thanks to a bug.  Make sure that an explicit master
     // channel gets post-processed.
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
-    pFileBpm1->set(160.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ProcessBuffer();
@@ -1128,15 +1129,15 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
 TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
     ProcessBuffer();
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(120.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
@@ -1168,10 +1169,6 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm1->set(128.0);
-    pFileBpm2->set(128.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
@@ -1204,12 +1201,8 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
 }
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(70);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(140);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
@@ -1275,10 +1268,6 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
 TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(80.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(175.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 175, 0.0);
@@ -1364,10 +1353,6 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(70.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(140.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
@@ -1403,8 +1388,6 @@ QVector<double> createBeatVector(double first_beat,
 
 TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     // half-double matching should be consistent
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(90.0);
     double beatLengthFrames = 60.0 * 44100 / 90.0;
     double startOffsetFrames = 0;
     const int numBeats = 100;
@@ -1412,8 +1395,6 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     auto pBeats1 = new BeatMap(*m_pTrack1, 0, beats1);
     m_pTrack1->setBeats(BeatsPointer(pBeats1));
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(145.0);
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<double> beats2 = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats2 = new BeatMap(*m_pTrack2, 0, beats2);
@@ -1437,9 +1418,9 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
 }
 
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
-    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
     ASSERT_EQ(130.0, m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
 }
 
@@ -1448,18 +1429,14 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     // deck if there are no sync decks and the non-sync deck is playing.
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    pFileBpm2->set(100.0);
 
     // Set the sync deck playing with nothing else active.
     // Next Deck becomes master and the Master clock is set to 100 BPM
@@ -1531,12 +1508,10 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
 
     // But if there is a third deck that is sync-enabled, we match that.
     auto pButtonSyncEnabled3 = std::make_unique<ControlProxy>(m_sGroup3, "sync_enabled");
-    auto pFileBpm3 = std::make_unique<ControlProxy>(m_sGroup3, "file_bpm");
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 140, 0.0);
     m_pTrack3->setBeats(pBeats3);
-    pFileBpm3->set(140.0);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
     ProcessBuffer();
@@ -1570,10 +1545,6 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // If a deck has a user tweak, and another deck stops such that the first
     // is used to reseed the master beat distance, make sure the user offset
     // is reset.
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(128.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(128.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
@@ -1618,10 +1589,6 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
 }
 
 TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(128.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
-    pFileBpm2->set(128.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
@@ -1668,13 +1635,13 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 }
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(128.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    m_pTrack1->setBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
 
-    pFileBpm1->set(0.0);
+    m_pTrack1->setBeats(BeatsPointer());
     EXPECT_EQ(128.0,
               ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 }
@@ -1682,8 +1649,6 @@ TEST_F(EngineSyncTest, MasterBpmNeverZero) {
 TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // If a track has a zero bpm and a bad beatgrid, make sure the rate
     // doesn't end up something crazy when sync is enabled..
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(0.0);
     // Maybe the beatgrid ended up at zero also.
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0.0, 0.0);
     m_pTrack1->setBeats(pBeats1);
@@ -1704,16 +1669,12 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsync1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync");
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    pFileBpm2->set(100.0);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -1802,8 +1763,6 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
@@ -1823,9 +1782,6 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(128.0);
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
     m_pTrack2->setBeats(BeatsPointer());
@@ -1845,16 +1801,12 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 }
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    pFileBpm1->set(130.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    pFileBpm2->set(100.0);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
 
@@ -1906,13 +1858,10 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
-    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
-    auto pFileBpm2 = std::make_unique<ControlProxy>(m_sGroup2, "file_bpm");
 
     // set beatgrid
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    pFileBpm1->set(130.0);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
 
@@ -1939,7 +1888,6 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     // Load a new beatgrid, this happens when the analyser is finisched
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    pFileBpm2->set(140.0);
 
     ProcessBuffer();
 
@@ -1953,7 +1901,6 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
     BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(*m_pTrack2, 75, 0.0);
     m_pTrack2->setBeats(pBeats2n);
-    pFileBpm2->set(75.0);
 
     ProcessBuffer();
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -69,7 +69,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
     connect(setFocusShortcut,
             &QShortcut::activated,
             this,
-            qOverload<>(&WTrackTableView::setFocus));
+            QOverload<>::of(&WTrackTableView::setFocus));
 }
 
 WTrackTableView::~WTrackTableView() {


### PR DESCRIPTION
This fixes some nasty double / half Bpm situations.

Please have a look at src/test/enginesynctest.cpp first. 
The tests partly tests the old behavior and the code had workarounds to make the test still succeed. 

I have adjusted the test to the new assumptions and cleaned up the code accordingly. 

The main assumption are: 

* A master never changes speed due to other decks. 
* If I enable sync on one deck, only this deck changes tempo. 

This works now with playing and paused decks in the same way. 

I have also re-enabed the explicit master feature. The state is always accepted for a deck and keept in standby until the deck has a valid tempo. As we know bad things kan happen in the head of the night with it. But since it is only accessible by special mappings, it is OK for me.  

 

